### PR TITLE
Cytoscape

### DIFF
--- a/Example Graph JSON.md
+++ b/Example Graph JSON.md
@@ -1,0 +1,139 @@
+This is how to add nodes and edges to the graph. I'm using Flow type notation:
+```
+type Node = {|
+  ?group: "nodes",
+  data: {
+    id: string | number,
+    // Other values as necessary. These can be accessed with Node.data()
+  },
+  position: {| // Only required if the nodes are added after initialization
+    x: number, // "model position" which is not scaled by zoom
+    y: number, // "model position" which is not scaled by zoom
+  |},
+  renderedPosition: {| // Can use in place of position
+    x: number, // pixels
+    y: number, // pixels
+  |},
+  ?selected: boolean,
+  ?classes: string, // space separated class list
+|};
+type Edge = {|
+  ?group: "edges",
+  data: {
+    id: string | number,
+    source: string | number, // Node id
+    target: string | number, // Node id
+    // Other values as necessary. These can be accessed with Node.data()
+  },
+|},
+type Element = Node | Edge;
+type Elements = Array<Element>;
+```
+
+Here is a sample of some JSON which produces a simple graph.
+```json
+{
+  "elements": [
+    {
+      "group": "nodes",
+      "data" : {
+         "id": "n1"
+       },
+       "position": {
+         "x": 0,
+         "y": 0
+       }
+    },
+    {
+      "group": "nodes",
+      "data" : {
+         "id": "n3"
+       },
+       "position": {
+         "x": 100,
+         "y": 0
+       }
+    },
+    {
+      "group": "nodes",
+      "data" : {
+         "id": "n4"
+       },
+       "position": {
+         "x": 0,
+         "y": 100
+       }
+    },
+    {
+      "group": "nodes",
+      "data" : {
+         "id": "n5"
+       },
+       "position": {
+         "x": 100,
+         "y": 100
+       }
+    },
+    {
+      "group": "nodes",
+      "data" : {
+         "id": "n2"
+       },
+       "position": {
+         "x": 50,
+         "y": 50
+       }
+    },
+
+
+    {
+      "group": "edges",
+      "data": {
+        "id": "e1",
+        "source": "n1",
+        "target": "n2"
+      }
+    },
+    {
+      "group": "edges",
+      "data": {
+        "id": "e2",
+        "source": "n1",
+        "target": "n3"
+      }
+    },
+    {
+      "group": "edges",
+      "data": {
+        "id": "e3",
+        "source": "n5",
+        "target": "n2"
+      }
+    },
+    {
+      "group": "edges",
+      "data": {
+        "id": "e4",
+        "source": "n4",
+        "target": "n5"
+      }
+    },
+    {
+      "group": "edges",
+      "data": {
+        "id": "e5",
+        "source": "n3",
+        "target": "n5"
+      }
+    },
+    {
+      "group": "edges",
+      "data": {
+        "id": "e6",
+        "source": "n2",
+        "target": "n4"
+      }
+    }
+  ]
+}
+```

--- a/Example Graph JSON.md
+++ b/Example Graph JSON.md
@@ -37,51 +37,36 @@ Here is a sample of some JSON which produces a simple graph.
     {
       "group": "nodes",
       "data" : {
-         "id": "n1"
-       },
-       "position": {
-         "x": 0,
-         "y": 0
+         "id": "n1",
+         "url": "http://www.somewhere.com/n1"
        }
     },
     {
       "group": "nodes",
       "data" : {
-         "id": "n3"
-       },
-       "position": {
-         "x": 100,
-         "y": 0
+         "id": "n2",
+         "url": "http://www.somewhere.com/n2"
        }
     },
     {
       "group": "nodes",
       "data" : {
-         "id": "n4"
-       },
-       "position": {
-         "x": 0,
-         "y": 100
+         "id": "n3",
+         "url": "http://www.somewhere.com/n3"
        }
     },
     {
       "group": "nodes",
       "data" : {
-         "id": "n5"
-       },
-       "position": {
-         "x": 100,
-         "y": 100
+         "id": "n4",
+         "url": "http://www.somewhere.com/n4"
        }
     },
     {
       "group": "nodes",
       "data" : {
-         "id": "n2"
-       },
-       "position": {
-         "x": 50,
-         "y": 50
+         "id": "n5",
+         "url": "http://www.somewhere.com/n5"
        }
     },
 
@@ -123,7 +108,7 @@ Here is a sample of some JSON which produces a simple graph.
       "data": {
         "id": "e5",
         "source": "n3",
-        "target": "n5"
+        "target": "n3"
       }
     },
     {

--- a/public/index.html
+++ b/public/index.html
@@ -3,8 +3,14 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8">
-		<title>Graphical Crawler</title>	
+		<title>Graphical Crawler</title>
+		<link rel="stylesheet" href="./styles.css"></link>
 	</head>
-	<body>Graphical Crawler Main Page</body>
+	<body>
+		<h1>Graphical Crawler Main Page<h1>
+		<textarea id="test" rows="8" cols="80"></textarea>
+		<div id="cyChart"></div>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.2.3/cytoscape.min.js"></script>
+		<script src="./index.js"></script>
+	</body>
 </html>
-

--- a/public/index.js
+++ b/public/index.js
@@ -5,7 +5,7 @@ const DEFAULT_JSON = {
       selector: "node",
       style: {
         "background-color": "#555",
-        "label": "data(id)", // define node labels to be their ids
+        "label": "data(label)", // call data("label") on the node
       },
     },
     {
@@ -16,12 +16,45 @@ const DEFAULT_JSON = {
       },
     },
   ],
+  minZoom: 0.2,
+  maxZoom: 5,
+  layout: {
+    name: "cose",
+    animate: false,
+  },
 };
 
 function main() {
-  // Initialize cytoscape
-  let cy = cytoscape(DEFAULT_JSON);
+  // Initialize cytoscape. TODO: take it off of window
+  window.cy = cytoscape(DEFAULT_JSON);
 
+  // Make the url show up above the node when it is hovered
+  cy.on("mouseover", "node", (ev) => {
+    let node = ev.target;
+    let label = node.data("url") || "[undefined]";
+    // The "label" field of the data object is usually empty. Give it a value.
+    node.data("label", label);
+  });
+  cy.on("mouseout", "node", (ev) => {
+    let node = ev.target;
+    node.data("label", null); // remove the label from the field
+  });
+
+  // Make the selected page open in a new tab when clicked
+  cy.on("click", "node", (ev) => {
+    let url = ev.target.data("url");
+    if (!url) {
+      // The node is displaying [undefined] right now, so the user will not be
+      // surprised if this does nothing.
+      return;
+    }
+    window.open(url);
+  });
+
+  /*
+  *****************************************************************************
+  TODO: make the JSON come from the server, not from pasting it into a textarea
+  */
   let test = document.getElementById("test");
   test.onchange = function (ev) {
     let value = ev.target.value;
@@ -32,6 +65,11 @@ function main() {
       return; // don't waste time with invalid JSON
     }
     cy.json({ ...DEFAULT_JSON, ...value });
+    setTimeout(() => {
+      // lay out the nodes more cleanly
+      let coseLayout = cy.layout({ name: "cose" });
+      coseLayout.run();
+    });
   }
 }
 

--- a/public/index.js
+++ b/public/index.js
@@ -1,0 +1,38 @@
+const DEFAULT_JSON = {
+  container: document.getElementById("cyChart"),
+  style: [
+    {
+      selector: "node",
+      style: {
+        "background-color": "#555",
+        "label": "data(id)", // define node labels to be their ids
+      },
+    },
+    {
+      selector: "edge",
+      style: {
+        "width": 3,
+        "background-color": "#ccc",
+      },
+    },
+  ],
+};
+
+function main() {
+  // Initialize cytoscape
+  let cy = cytoscape(DEFAULT_JSON);
+
+  let test = document.getElementById("test");
+  test.onchange = function (ev) {
+    let value = ev.target.value;
+    try {
+      value = JSON.parse(value.trim());
+    } catch (err) {
+      console.log("invalid json: " + value);
+      return; // don't waste time with invalid JSON
+    }
+    cy.json({ ...DEFAULT_JSON, ...value });
+  }
+}
+
+main();

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,5 @@
+#cyChart {
+  width: 800px;
+  height: 600px;
+  border: 1px solid black;
+}


### PR DESCRIPTION
Create a Cytoscape sandbox. Placing arbitrary JSON into the `textarea` will render the relevant chart below.
* Make the URLs appear when the user hovers over the node
* Make the nodes clickable
* Make the nodes lay themselves out nicely.
* Add some docs for reference of how to add JSON to Cytoscape.

The JSON which Cytoscape accepts is not in the same format as the JSON the database interacts with, but this is OK. We probably shouldn't let our front-end graphics library drive our back-end data generation. Also, the back end will need to provide us with cookies and other information which is unrelated to Cytoscape. In a later PR I will create an adapter to convert server JSON to Cytoscape JSON, but until then it's easier to just write Cytoscape JSON in the textarea.

Here's a picture:
![graph_wee_3](https://user-images.githubusercontent.com/2568069/31322518-9d512f3c-ac56-11e7-8026-02ac812743af.PNG)
