### PR TITLE
Refactor breadthFS to use promises

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -8,7 +8,7 @@ var search = require('./lib/searches');
 // Create server object
 var app = express();
 
-// Set port 
+// Set port
 app.set('port', 5545);
 app.use(bodyParser.urlencoded({extended: false}));
 app.use(express.static('public'));
@@ -20,33 +20,43 @@ app.get('/', function(req, res, next) {
 
 // POST to crawler
 app.post('/crawl', function(req, res, next) {
-    var edges = [];
-    
     if(req.body.SearchType == "BFS") {
-        search.breadthFS(req.body.RootURL, req.body.SearchDepth, edges, function(err){
-            if(err){ 
-                next(err); 
-                return; 
-            }
+        // return a promise from search.breadthFS. Now we can add success and
+        // failure handlers to the promise instead of as a callback. "then"
+        // handlers are called when a promise resolve, and "catch" handlers are
+        // called when it rejects (this happens automatically if there's an
+        // error). When a handler returns, its return value (or thrown error) is
+        // packacged into the same promise, so you can call it like:
+        // promise.then(stuffWhichReturnsANumber);
+        // promise.then(stuffWhichUsesThatNumber);
+        // promise.catch(stuffToDoWithErrors);
+        var bfs = search.breadthFS(req.body.RootURL, req.body.SearchDepth);
+
+        bfs.then((edges) => {
             res.send(edges);
+        })
+
+        bfs.catch((err) => {
+            next(err);
+            return;
         });
     }
 });
 
 // 404 Error
 app.use(function(req,res){
-   res.status(404)
-   res.send('404 - Page not found.');
+    res.status(404)
+    res.send('404 - Page not found.');
 });
 
 // 500 Error
 app.use(function(err, req, res, next){
-  console.error(err.stack);
-  res.type('plain/text');
-  res.status(500)
-  res.send('500 - Something went wrong.');
+    console.error(err.stack);
+    res.type('plain/text');
+    res.status(500)
+    res.send('500 - Something went wrong.');
 });
 
 app.listen(app.get('port'), function(){
-  console.log('Express started on http://flip3.engr.oregonstate.edu:' + app.get('port') + '; press Ctrl-C to terminate.');
+    console.log('Express started on http://flip3.engr.oregonstate.edu:' + app.get('port') + '; press Ctrl-C to terminate.');
 });

--- a/lib/searches.js
+++ b/lib/searches.js
@@ -1,81 +1,132 @@
-var request = require('request');
+var request = require('request-promise-native');
 var cheerio = require('cheerio');
-var async = require('async');
 var validUrl = require('valid-url');
 
-var bfsHelper = function (url, edges, toCrawl, searchDepth, level, callback) { 
-    // Get URL. If there is an error, do not add URL to toCrawl list
-request({url: url, jar: true}, function(err, resp, body){
-        if(!err) {
-            // Load HTML and get all links in page
-            var $ = cheerio.load(body);
-            var sourceTitle = $("title").text();
-            links = $('a'); 
-           
-            // Add all valid links to edges array
-            $(links).each(function(i, link){
-                var linkUrl = $(link).attr("href");
-                if(linkUrl != "javascript:void(0)" && validUrl.isUri(linkUrl)){
-                    edges.push({
-                        "SourceUrl": url,
-                        "SourceTitle": sourceTitle,
-                        "DestinationUrl": linkUrl,
-                        "Level": level
-                    });
-                    // Add links that need to be crawled to toCrawl array
-                    if (level < searchDepth) {
-                        toCrawl.push({
-                            url: linkUrl,
-                            level: level
-                        });
-                    }
-                }
-            });
-        }
-        callback();
-    });
+var getEdgesFromDatabase = (url) => {
+    // TODO: return null if there were no edges. Otherwise return nice JSON
 }
 
+var bfsHelper = function (url, edges, toCrawl, searchDepth, level) {
+    // test for presence in database first (doesn't work)
+    var existingEdges = getEdgesFromDatabase(url);
+    if (existingEdges) {
+        existingEdges.forEach((edge) => {
+          edges.push(edge);
+        });
+        // We don't want to continue and make an HTTP request, but we also don't
+        // have a promise to return yet. Because breadthFS called us and expects
+        // a promise, we have to be sure to return one. This may seem hard to
+        // remember, but my work IDE has a rule which tells you when you have
+        // inconsistent return statements. I'll add linting to this project, but
+        // for now we just remember to return a promise. The native Promise
+        // class has a handy shortcut for creating a promise which is already
+        // resolved, which is exactly what we want.
+        return Promise.resolve();
+        // There's a similar static method Promise.reject() for making rejected
+        // promises, as well.
+    }
+    // Get URL. If there is an error, do not add URL to toCrawl list
+    var helperPromise = request({url: url, jar: true});
+    helperPromise.then((body) => {
+        // Load HTML and get all links in page
+        var $ = cheerio.load(body);
+        var sourceTitle = $("title").text();
+        console.log("Link <title>", sourceTitle);
+        links = $('a');
 
-var breadthFS = function (url, searchDepth, edges, callback) {  
+        // Add all valid links to edges array
+        $(links).each(function(i, link){
+            var linkUrl = $(link).attr("href");
+            if(linkUrl != "javascript:void(0)" && validUrl.isUri(linkUrl)){
+                edges.push({
+                    "SourceUrl": url,
+                    "SourceTitle": sourceTitle,
+                    "DestinationUrl": linkUrl,
+                    "Level": level
+                });
+                // Add links that need to be crawled to toCrawl array
+                if (level < searchDepth) {
+                    toCrawl.push({
+                        url: linkUrl,
+                        level: level
+                    });
+                }
+            }
+        });
+    });
+    helperPromise.catch((err) => {
+      // We don't do anything if there is an error. The helperPromise object,
+      // which was "rejected" by whatever caused this error, is changed to
+      // "resolved" when it calls this "catch" handler. After this is done doing
+      // whatever it needs to with the error (nothing, in this case), the
+      // helperPromise will continue through its list of callbacks as though
+      // nothing went wrong. For us, since we return this promise and chain a
+      // then handler below, the next "then" is called which will search the
+      // next link in the list.
+    });
+
+    return helperPromise;
+}
+
+// Note on searchDepth parameter:
+// * A searchDepth of 0 terminates immediately.
+// * A searchDepth of 1 performs 1 request on the root url, and then stops with
+//   all the links in edges
+// * A searchDepth of 2 gets all the links on each page linked to the first page
+var breadthFS = function (url, searchDepth) {
     // Add root URL to toCrawl array
     var toCrawl = [{url: url, level: 0}];
     var currentDepth = 0;
-    
-    // While searchDepth not reached, continue to crawl
-    async.whilst(function() {
-        return currentDepth < searchDepth;
-    },
-    function(next) {
-        console.log("Crawling level " + (currentDepth + 1) + "...");
-        
-        // Crawl each URL in toCrawl array
-        async.each(toCrawl, function(urlToCrawl, callback) {
-            if (urlToCrawl.level == currentDepth) {
-                bfsHelper(urlToCrawl.url, edges, toCrawl, searchDepth, currentDepth + 1, function(){ 
-                    callback();
-                });       
-            }
-        }, function(err){
-            if (err){
-                callback(err);
+    var edges = [];
+
+    // Create a Promise to return to crawler.js
+    // A Promise will immediately execute the function you pass it, but it won't
+    // call the "then" callbacks until this function has called "resolve" or
+    // "reject". This is different from the "then" and "catch" callbacks, which
+    // resolve when they return and reject when they throw errors.
+    var searchingPromise = new Promise((resolve, reject) => {
+        console.log("Crawling level 0...");
+
+        // Removing the first element of an array and adding to the end makes the
+        // array act like a queue. If you remember from data structures, a queue
+        // was used for BFS. The links we get from the first URL will go on the
+        // end of the queue, and we will search everything else before reaching
+        // them. Then we have to do all of the to see the results from the
+        // second link, etc, etc, until either there are no links or we reach
+        // the search depth.
+        function getLinksForFirstURL() {
+            if (toCrawl.length === 0) {
+                // we have no more links, resolve the promise with our results.
+                resolve(edges);
                 return;
             }
-            // Pop all crawled URLs from toCrawl list
-            for (i = 0; i < toCrawl.length; i++){
-                if(toCrawl[0] && toCrawl[0].level == currentDepth) {
-                    toCrawl.shift();
-                }
+
+            // remove the first url from the array and search it.
+            var urlToCrawl = toCrawl.shift();
+            if (urlToCrawl.level >= searchDepth) {
+              // we have searched all the links up to searchDepth. We're done.
+              resolve(edges);
+              return;
             }
-            // Continue to next search depth level
-            currentDepth++;             
-            next();
-        }); 
-    },
-    function(err) {;
-        console.log("Finished crawling!")
-        callback(err);
+            if (urlToCrawl.level > currentDepth) {
+              // we are finished with the "current" level and have reached a new one
+              console.log("Crawling level " + urlToCrawl.level + "...");
+              currentDepth = urlToCrawl.level;
+            }
+
+            // we still have searching to do...
+            var helperPromise = bfsHelper(urlToCrawl.url, edges, toCrawl, searchDepth, urlToCrawl.level + 1);
+            // ...and do again, recursively, until a base case is reached...
+            helperPromise.then(getLinksForFirstURL);
+            // ...or something breaks (pretty much impossible since we catch
+            // errors in the bfsHelper)
+            helperPromise.catch(reject);
+        }
+
+        getLinksForFirstURL();
     });
+
+    return searchingPromise;
 }
 
 var depthFS = function () {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Graphical Crawler for CS467",
   "main": "crawler.js",
   "scripts": {
+    "stop": "./node_modules/forever/bin/forever stopall",
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "./scripts/start"
   },
@@ -11,10 +12,11 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.13.3",
+    "cheerio": "latest",
     "express": "^4.13.2",
     "forever": "^0.15.3",
     "mysql": "^2.8.0",
-    "request": "^2.80.0",
-    "cheerio": "latest"
+    "request-promise-native": "^1.0.5",
+    "valid-url": "^1.0.9"
   }
 }


### PR DESCRIPTION
I tried to keep the logic the same, but there isn't really a "whilst" for promises (well, there is, but it's not supported by node 6.10.2. I would use the `async` keyword and that's in 7.10.1). I switched to using a recursive search algorithm with a queue, which implements Breadth First Search if you remember from data structures.

It might be helpful for you two to add the query param `w=1` to the url for this PR. I'll try to remember. The `w` flag is a special Github hack which allows you to turn on the "ignore whitespace" option for viewing diffs, so the code which only moved left because it needed fewer indents will disappear.

Anyways, here's promises. As a shorter example, imagine I have some variables `a`, `b`, and `c`, and want to do something asynchronous to them, but when its done, you still need to know. Basically a promise turns this callback-y form of doing that:
```js
doSomethingAsync(a, b, c, (result, err) => {
  if (err) {
    logToErrorLog(error);
    return;
  }
  doNextImportantThing(result);
});
```
into this:
```js
doSomethingAsync(a, b, c).then(doNextImportantThing).catch(logToErrorLog);
```
Such pretty! Very one-line! Wow!

Of course, there is a cost. The extra work that the callback style had to do while defining the callback needs to be done by our `doSomethingAsync` function inside itself so it can return a `Promise`. Let's imagine that `doSomethingAsync` looked like this before:
```js
function doSomethingAsync(a, b, c, callback) {
  var err;
  try {
     var result = a + b + c;
  } catch (e) {
     err = e;
  }
  // for some reason we only want to know the result 5 seconds from now
  setTimeout(() => callback(result, err), 5000);
}
```
Now it needs to return a promise, so it does something like:
```js
function doSomethingAsync(a, b, c) {
  return new Promise((resolve, reject) => {
    var result = a + b + c;
    setTimeout(() => resolve(result), 5000);
  };
}
```
We basically take the old function, send the whole thing into a `Promise` constructor, and return the result.
But why? First, compare the last two code blocks. Notice how there is no `try`/`catch`. Promises know that when the code inside them executes, they have no guarantee that the function which called `doSomethingAsync` is on the stack anymore. They could happen at any time, which means they can throw errors at any time. In order to deal with this, whenever an error is thrown they catch it inside the Promise object, and choose to deal with it later when they have time. I'll show you in more detail, but it's in the `catch(logToErrorLog)` call above.
The next thing to notice is that `resolve` is acting a lot like `callback`. A Promise gives you `callback` without you having to define anything. Also notice how `resolve` doesn't receive the `err` variable, since all the exceptions are handled automatically. This cleans up your callback code. Adeline probably noticed that she always had to check `if (!err) { ... }` before doing anything with her callbacks, but that's no longer an issue.
The Promise setup code looks a little cleaner, but I think it's harder to write and read because I have to remember all this stuff about Promises, so it's a trade-off. The real-world use case for a Promise is when you have several callbacks which need to be nested.
```js
app.post('/user', (req, res, next) => {
  createUser(req.body).then(() => {
    res.send("OK response");
  }).catch(next);
});

function createUser(data) {
  return getPaymentAccountId(data.memberLevel, data.id).then((accountId) => {
    new User(data, accountId).save(); // this will throw error if the data is invalid
  }).catch((err) => {
    removePaymentAccount(data.id);
    throw err;
  });
}

function getPaymentAccountId(memberLevel, userId) {
  // the payment company doesn't use promises in their API. Boo!
  return new Promise((resolve, reject) => {
    var api = new PaymentApi(API_KEY);
    api.createPaymentAccountForUser(memberLevel, userId, (response, err) => {
      if (err) {
        reject(err); // let who ever called us deal with it.
        return;
      }
      resolve(response.body.acctId);
    });
  });
}
// and I don't want to implement removePaymentAccount
```
If we were to write that in the callback style it would be:
```js
app.post('/user', (req, res, next) => {
  createUser(req.body, (err) => {
    if (err) {
      next(err);
      return;
    }
    res.send("OK response");
});

function createUser(data, callback) {
  getPaymentAccount(data.memberLevel, data.id, (accountId, err) => {
    if (err) {
      removePaymentAccount(data.id);
      callback(); // don't forget callback here, or the request will never finish!
      return;
    }
    try {
      new User(data, accountId).save();
    } catch (e) {
      // we have to handle both errors the same, but do so in different places
      removePaymentAccount(data.id);
      callback(e);
    }
  });
}

function getPaymentAccount(memberLevel, userId, callback) {
  var api = new PaymentApi(API_KEY);
  api.createPaymentAccountForUser(memberLevel, userId, (response, err) => {
    if (err) {
      callback(null, err); // what was the callback signature again?
      return;
    }
    callback(response.body.acctId);
  });
}
```
I might be getting a little over-critical. Callbacks are extremely powerful, and Promises don't solve everything magically, but it's definitely nice when you get used to it.

In dealing with the nested callbacks, the Promise solution used "chained callbacks". Essentially, whenever you call `then` or `catch` on a promise, you are adding a handler to a queue inside it. They both take a handler to put on the queue, and then return the original Promise object so you can keep chaining, or return the object somewhere else and chain onto it from there. If we step through the user-creation code above:
1) We get a request. Call `createUser` with the request body.
2) `createUser` calls `getPaymentAccount` with some info.
3) `getPaymentAccount` creates a promise, which happens to wrap an API call. Let's name it `apiPromise`.
4) `apiPromise` is returned. It has no handlers and is "pending" until the API call is done.
5) `createUser` receives `apiPromise` and calls `then`, adding a handler to the queue and returning the promise again. Queue: `[then]`
6) The returned `apiPromise` calls `catch`, chaining another handler. Queue `[then, catch]`
7) `createUser` returns `apiPromise` to the '/user' handler, which chains a `then` and a `catch` call. Queue: `[then, catch, then, catch]`
...
8) Some time later, the API call finishes. We're busy, so we wait a moment, which is OK since we're asynchronous already.
9) When we have a moment, the API callback calls `reject`. Now `apiPromise` changes from "pending" to "rejected" and calls its callbacks.
10) `apiPromise` looks at the first handler in the queue and sees that it's a `then`. `then` handlers are not called on "rejected" promises, so it removes it from the queue and tries the next one. Queue: `[catch, then, catch]`
11) Huzzah! A `catch` handler! `apiPromise` calls it with the error. The handler removes the broken user account somehow and then throws an error. If this handler _didn't_ throw an error then `apiPromise` would be changed from "rejected" to "resolved", because the error was properly handled. Since an error was thrown, though, it stays "rejected". Queue: `[then, catch]`
12) `apiPromise` catches the error, because that's how errors work in promises. Once again it skips the next `then` handler until it sees the `catch`. This is just the standard express `next`, so we do whatever we need with that error (probably send the client a 500). `apiPromise` marks itself "resolved" because the error was handled.

Had the API call succeeded, we would have seen some `then` handlers get called and some `catch` handlers get skipped, because `catch` handlers are skipped for "resolved" promises the same way `then` handlers are skipped for "rejected" promises.