### PR TITLE
Add test packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Graphical Crawler for CS467",
   "main": "crawler.js",
   "scripts": {
+    "test": "mocha -r ./test/setup.js",
+    "test:amazing": "mocha -r ./test/setupAmazing -R nyan",
     "stop": "./node_modules/forever/bin/forever stopall",
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "./scripts/start"
@@ -18,5 +20,11 @@
     "mysql": "^2.8.0",
     "request-promise-native": "^1.0.5",
     "valid-url": "^1.0.9"
+  },
+  "devDependencies": {
+    "chai": "^4.1.2",
+    "mocha": "^4.0.1",
+    "sinon": "^4.0.1",
+    "sinon-chai": "^2.14.0"
   }
 }

--- a/test/sandbox.test.js
+++ b/test/sandbox.test.js
@@ -1,0 +1,29 @@
+/* global describe, it, beforeEach, sinon, expect, isAmazing */
+describe("passing test", function() {
+    it("passes", function() {
+        expect(true).to.equal(true);
+    });
+});
+
+describe("sinon API", function() {
+    let func;
+    beforeEach(function() {
+        func = sinon.spy();
+    });
+
+    it("spies can be called and their information read", function() {
+        expect(func).to.not.have.been.called;
+        func("__super secret recipe__");
+        expect(func).to.have.been.called;
+        expect(func).to.have.been.calledOnce;
+        expect(func).to.have.been.calledWith("__super secret recipe__");
+    });
+});
+
+if (isAmazing) {
+    describe("Amazing, programmtically defined test", function() {
+        for (let i = 0; i < 50; i++) {
+            it("runs 50 times", function() {});
+        }
+    });
+}

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,14 @@
+const chai = require("chai");
+const sinon = require("sinon");
+const sinonChai = require("sinon-chai");
+
+// expand chai to support sinon spies like expect(spy).to.have.been.called;
+chai.use(sinonChai);
+
+// define certain globals so they can be used in tests
+// - expect: expect(value).to.be(condition);
+global.expect = chai.expect;
+// - sinon: let mockedFunction = sinon.spy();
+global.sinon = sinon;
+// - flag for AMAZING test reporter
+global.isAmazing = false;

--- a/test/setupAmazing
+++ b/test/setupAmazing
@@ -1,0 +1,4 @@
+require("./setup");
+
+global.isAmazing = true;
+


### PR DESCRIPTION
This uses mocha to run tests with a [BDD](https://mochajs.org/#bdd) style (describe, it, beforeEach...). I made `chai.expect` global and added support for `sinon` spies. This gives us test like:
```js
expect([1, 2]).to.include(2);
expect({ a: 1 }).to.deep.equal({ a: 1 });
let fakeCallback = sinon.spy();
thing(fakeCallback);
expect(fakeCallback).to.have.been.calledWith("args passed by thing");
```
Docs for the expect syntax are [here](http://chaijs.com/api/bdd/). For help with spy test syntax use the [sinon-chai](https://github.com/domenic/sinon-chai) and the [sinon](http://sinonjs.org/releases/v4.0.1/) docs.

`npm run test` and `npm run test:amazing` will run anything in the `test/` directory which ends in `.js`. I recommend putting your files in a corresponding folder in this directory to where they are in the "real" world. So when I write a test for `public/index.js` it will go in `test/public/index.js`