### PR TITLE
Clean up

### DIFF
--- a/lib/searches.js
+++ b/lib/searches.js
@@ -307,7 +307,7 @@ let depthFS = function (searchID, rootURL, searchDepth, keyword) {
                 console.error(err);
                 result.status = INVALID;
                 resolve(result);
-                return; 
+                return;
             });
         }
 

--- a/public/PreviousSearches.js
+++ b/public/PreviousSearches.js
@@ -21,6 +21,7 @@ window.Hercules.PreviousSearches = class PreviousSearches {
             herculesCookie = "";
         }
         let searchCookie = new window.Hercules.SearchCookie(herculesCookie);
+        window.Hercules.cookie = searchCookie;
         this.searches = [ { id: 0, text: "--" } ];
         searchCookie.getCookies().forEach((cookie) => {
             this.searches.push({

--- a/public/SearchCookie.js
+++ b/public/SearchCookie.js
@@ -33,7 +33,7 @@ class SearchCookie {
     }
 
     addCookie(id, searchType, searchDepth, rootURL, keyword) {
-        if (this._cookies.findIndex((cookie) => cookie.cookieID === id) > -1) {
+        if (this.withID(id)) {
             // we don't need to add cookies which already exist
             return;
         }

--- a/public/SearchCookie.js
+++ b/public/SearchCookie.js
@@ -33,6 +33,10 @@ class SearchCookie {
     }
 
     addCookie(id, searchType, searchDepth, rootURL, keyword) {
+        if (this._cookies.findIndex((cookie) => cookie.cookieID === id) > -1) {
+            // we don't need to add cookies which already exist
+            return;
+        }
         this._cookies.unshift({ // put the new cookie at the "top" of the list
             cookieID: id,
             searchType: searchType,

--- a/public/SearchForm.js
+++ b/public/SearchForm.js
@@ -51,6 +51,20 @@ window.Hercules.SearchForm = class SearchForm {
         });
     }
 
+    disable() {
+        if (!this.submit) {
+            return;
+        }
+        this.submit.disabled = true;
+    }
+
+    enable() {
+        if (!this.submit) {
+            return;
+        }
+        this.submit.disabled = false;
+    }
+
     updatePreviousSearches() {
         if (this.prevSearches) {
             this.prevSearches.update();

--- a/public/chart.js
+++ b/public/chart.js
@@ -6,8 +6,12 @@ window.Hercules.setUpChart = function setUpChart() {
             {
                 selector: "node",
                 style: {
-                    "background-color": "#555",
                     "label": "data(label)", // call data("label") on the node
+                    "background-color": "data(color)",
+                    "text-wrap": "wrap",
+                    "border-color": "#ccc",
+                    "border-width": 4,
+                    "border-opacity": 0.5,
                 },
             },
             {
@@ -19,7 +23,7 @@ window.Hercules.setUpChart = function setUpChart() {
             },
         ],
         minZoom: 0.2,
-        maxZoom: 5,
+        maxZoom: 4,
         layout: {
             name: "cose",
             animate: false,
@@ -35,7 +39,7 @@ window.Hercules.setUpChart = function setUpChart() {
     cy.on("mouseover", "node", (ev) => {
         let node = ev.target;
         let label = node.data("title") || "[undefined]";
-        label += " - ";
+        label += "\n";
         label += node.data("url") || "[undefined]";
         // The "label" field of the data object is usually empty. Give it a value.
         node.data("label", label);

--- a/public/chart.js
+++ b/public/chart.js
@@ -59,6 +59,9 @@ window.Hercules.setUpChart = function setUpChart() {
         }
         window.open(url);
     });
+
+    // show the "legend" now that the chart is visible
+    document.getElementById("legend").classList.remove("hidden");
 };
 
 window.Hercules.populateChart = function populateChart(json) {

--- a/public/colors.js
+++ b/public/colors.js
@@ -1,0 +1,34 @@
+/* global window */
+function colorScopingFunction() {
+    const COLORS = [ // several colors generated randomly at http://phrogz.net/css/distinct-colors.html
+        "#80407b",
+        "#53a674",
+        "#9886b3",
+        "#2d86b3",
+        "#608020",
+        "#5353a6",
+        "#59adb3",
+        "#862db3",
+        "#2d2080",
+        "#a65b29",
+        "#b25965",
+        "#69818c",
+        "#b39886",
+        "#b22d2d",
+        "#8c7723",
+        "#b0b386",
+        "#3eb32d"
+    ];
+    window.Hercules.KEYWORD_COLOR = "yellow";
+    let colorMap = {};
+    let currentColor = 0;
+
+    window.Hercules.getColorForHost = function getColorForHost(host) {
+        if (!colorMap[host]) {
+            colorMap[host] = COLORS[currentColor];
+            currentColor = (currentColor + 1) % COLORS.length;
+        }
+        return colorMap[host];
+    };
+}
+colorScopingFunction();

--- a/public/form.js
+++ b/public/form.js
@@ -20,12 +20,23 @@ window.Hercules.setUpForm = function setUpForm() {
         let errors = validateFormData(params);
         searchForm.applyErrors(errors);
         if (errors.length == 0) {
+            searchForm.disable();
             window.Hercules.sendFormData(params).then((json) => {
                 if (!json) {
                     return;
                 }
+                if (json.Result.status === -1) {
+                    searchForm.applyErrors([ {
+                        field: "RootURL",
+                        message: "This Url failed to return a valid web page."
+                    } ]);
+                }
                 searchForm.updatePreviousSearches();
-                window.Hercules.populateChart(json.Edges);
+                window.Hercules.populateChart(json);
+            }).then(() => {
+                searchForm.enable();
+            }).catch(() => {
+                searchForm.enable();
             });
         }
     };

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,11 @@
 	<body>
 		<h1>Graphical Crawler Main Page</h1>
 		<div id="root"></div>
+		<div id="legend" class="hidden">
+			<p>Nodes with the same color are pages with the same host.</p>
+			<p>If a keyword was found on a certain page, that page's node is colored yellow.</p>
+			<p><b>Scroll</b> to zoom. <b>Drag</b> to pan. <b>Click</b> nodes to visit the page</p>
+		</div>
 		<div id="cyChart"></div>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.2.3/cytoscape.min.js"></script>
 		<script src="./index.js"></script>

--- a/public/index.js
+++ b/public/index.js
@@ -30,14 +30,14 @@ window.Hercules.loadScripts = function loadScripts(scripts) {
 };
 
 window.Hercules.loadScripts([
+    "./loader.js", // This actually runs code to place a loader in the corner
     "./chart.js",
     "./colors.js",
     "./form.js",
-    "./loader.js",
     "./PreviousSearches.js",
     "./SearchCookie.js",
     "./SearchForm.js",
     "./serverApi.js",
     "./transformJSON.js",
-    "./run.js"
+    "./run.js" // this will start everything and remove the loader when done.
 ]);

--- a/public/index.js
+++ b/public/index.js
@@ -31,7 +31,9 @@ window.Hercules.loadScripts = function loadScripts(scripts) {
 
 window.Hercules.loadScripts([
     "./chart.js",
+    "./colors.js",
     "./form.js",
+    "./loader.js",
     "./PreviousSearches.js",
     "./SearchCookie.js",
     "./SearchForm.js",

--- a/public/loader.js
+++ b/public/loader.js
@@ -1,0 +1,17 @@
+/* global window, document */
+window.Hercules.showLoader = function showLoader() {
+    window.Hercules.hideLoader(); // just in case
+    let loader = document.createElement("div");
+    loader.classList.add("loader");
+    let container = document.createElement("div");
+    container.id = "loaderContainer";
+    container.appendChild(loader);
+    document.body.appendChild(container);
+};
+
+window.Hercules.hideLoader = function hideLoader() {
+    let container = document.getElementById("loaderContainer");
+    if (container) {
+        container.parentNode.removeChild(container);
+    }
+};

--- a/public/loader.js
+++ b/public/loader.js
@@ -15,3 +15,8 @@ window.Hercules.hideLoader = function hideLoader() {
         container.parentNode.removeChild(container);
     }
 };
+
+// Show the loader before requesting all the other code blocks, and then hide it
+// when we're done. This should be the only code which executes functionality
+// before all the code is loaded.
+window.Hercules.showLoader();

--- a/public/run.js
+++ b/public/run.js
@@ -1,3 +1,5 @@
 /* globals window */
 window.Hercules.setUpChart();
 window.Hercules.setUpForm();
+// remove the loader
+window.Hercules.hideLoader();

--- a/public/serverApi.js
+++ b/public/serverApi.js
@@ -1,5 +1,6 @@
 /* global window, fetch, Headers */
 window.Hercules.sendFormData = function sendFormData(params) {
+    window.Hercules.showLoader();
     // fetch is a Promise-based function which can be used instead of making
     // XMLHTTPRequest objects with callbacks. It is defined in most recent
     // browsers. Our code will only be tested in Chrome.
@@ -9,11 +10,13 @@ window.Hercules.sendFormData = function sendFormData(params) {
         credentials: "same-origin", // enable cookies
         body: JSON.stringify(params)
     }).then((response) => {
+        window.Hercules.hideLoader();
         if (!response.ok) {
             throw new Error("Server request returned " + response.statusText);
         }
         return response.json();
     }).catch((err) => {
+        window.Hercules.hideLoader();
         // fetch throws a network error if there was an internet issue.
         // We throw an error if there was an invalid server response like 500.
         // Additionally response.json() throws an error with invalid JSON.

--- a/public/styles.css
+++ b/public/styles.css
@@ -29,6 +29,17 @@ form {
   margin-bottom: 0.5em;
 }
 
+#legend {
+  text-align: right;
+}
+#legend > p {
+  font-size: 0.9em;
+  margin: 0.5em 0;
+}
+#legend.hidden {
+  display: none;
+}
+
 #cyChart {
   width: 800px;
   height: 600px;

--- a/public/styles.css
+++ b/public/styles.css
@@ -35,3 +35,55 @@ form {
   border: 1px solid black;
   background-color: white;
 }
+
+#loaderContainer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  padding: 5px;
+  border-bottom-left-radius: 5px;
+  background-color: #7fce63;
+}
+
+/* loader styles came from https://projects.lukehaas.me/css-loaders/ */
+.loader,
+.loader:after {
+  border-radius: 50%;
+  width: 10em;
+  height: 10em;
+}
+.loader {
+  /*margin: 60px auto;  I don't like this style*/
+  font-size: 10px;
+  position: relative;
+  text-indent: -9999em;
+  border-top: 1.1em solid rgba(255, 255, 255, 0.2);
+  border-right: 1.1em solid rgba(255, 255, 255, 0.2);
+  border-bottom: 1.1em solid rgba(255, 255, 255, 0.2);
+  border-left: 1.1em solid #ffffff;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+  -webkit-animation: load8 1.1s infinite linear;
+  animation: load8 1.1s infinite linear;
+}
+@-webkit-keyframes load8 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+@keyframes load8 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}

--- a/public/transformJSON.js
+++ b/public/transformJSON.js
@@ -50,11 +50,13 @@ window.Hercules.transformJSON = function transformJSON(json) {
         }
     });
 
-    // TODO: what about cached (status: 3) results?
-    if (json.Result.status === 2) {
-        // The search detected the keyword, change the color of that node.
-        let keywordNode = graphNodes.find((node) => node.data.url === json.Result.keywordURL);
-        keywordNode.data.color = window.Hercules.KEYWORD_COLOR;
+    if (json.Result.status === 2 || json.Result.status === 3) {
+        let keywordURL = json.Edges[0]["Keyword Url"];
+        if (keywordURL) {
+            // The search detected the keyword, change the color of that node.
+            let keywordNode = graphNodes.find((node) => node.data.url === keywordURL);
+            keywordNode.data.color = window.Hercules.KEYWORD_COLOR;
+        }
     }
 
     // Assume the N/A node is the first node, and same for edge. Remove them.


### PR DESCRIPTION
* De-dupe searches in drop down (searches were being added each time they were repeated.)
* Color nodes by hostname and keyword.
* Remove the unnecessary "N/A" node and edge.
* Show loading spinner.
* Disable submit button when a search is in progress.
* Provide an error message if a search fails.